### PR TITLE
Modified for Python 3 compatibility; relative packaging

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ Kivy-iconfonts
 Simple helper functions to make easier to use icon fonts in Labels and derived
 widgets.
 """
-from iconfonts import *
+from .iconfonts import *
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In Python 3, `from iconfonts import *` will not work.  It must be `from .iconfonts import *`.  I believe this is also compatible with Python 2.7.
